### PR TITLE
feat: prepare Chrome Web Store submission flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 .opencode/
 !.opencode/skill/
 !.opencode/skill/**
+artifacts/

--- a/CHROME_WEB_STORE.md
+++ b/CHROME_WEB_STORE.md
@@ -1,0 +1,72 @@
+# Chrome Web Store Submission Guide
+
+This document is the maintainer runbook to prepare and submit OpenCode Browser to the Chrome Web Store.
+
+## 1) Build a store-ready package
+
+From the repo root:
+
+```bash
+bun run build:cws
+```
+
+This generates:
+
+- `artifacts/chrome-web-store/opencode-browser-cws-v<version>.zip`
+- `artifacts/chrome-web-store/extension/` (staging folder)
+- `artifacts/chrome-web-store/manifest.chrome-web-store.json` (effective store manifest)
+
+## 2) What the store build changes
+
+The build script transforms `extension/manifest.json` for review-friendly defaults:
+
+- Removes `key` from the store manifest artifact
+- Moves broad site access from required `host_permissions` to `optional_host_permissions`
+- Moves `nativeMessaging`, `downloads`, and `debugger` to `optional_permissions`
+- Drops `notifications` from required permissions
+
+The extension requests optional permissions from the extension action click flow.
+
+## 3) Required listing assets and metadata
+
+Prepare these before submission:
+
+- Extension name, short and long descriptions
+- 128x128 icon
+- Chrome Web Store screenshots
+- Support URL (GitHub issues is acceptable)
+- Privacy policy URL (host `PRIVACY.md` on a public URL)
+
+## 4) Data disclosure form (recommended answers)
+
+OpenCode Browser can handle the following categories when a user asks it to automate pages:
+
+- Website content
+- User activity
+- Personal communications and PII (possible on user-selected sites)
+
+Use the policy in `PRIVACY.md` and disclose local native messaging architecture clearly.
+
+## 5) Permission justification text (copy starter)
+
+- `scripting` and site access: required to execute user-requested browser actions on pages the user authorizes.
+- `nativeMessaging`: required to connect Chrome extension commands to a local companion host process.
+- `debugger` (optional): used only for explicit diagnostics features (console and page errors).
+- `downloads` (optional): used for automation workflows that initiate downloads.
+
+## 6) Manual submission steps
+
+1. Sign in to Chrome Web Store Developer Dashboard.
+2. Create or open the draft listing.
+3. Upload `artifacts/chrome-web-store/opencode-browser-cws-v<version>.zip`.
+4. Complete privacy/data safety disclosures.
+5. Add screenshots, descriptions, and support links.
+6. Submit for review.
+
+## 7) Post-approval follow-up
+
+After first publish:
+
+1. Record the final store extension ID.
+2. Verify native host install path supports that ID (`--extension-id` flow in `bin/cli.js`).
+3. Update README installation flow to prefer Web Store install + local host install.

--- a/CHROME_WEB_STORE_LISTING_COPY.md
+++ b/CHROME_WEB_STORE_LISTING_COPY.md
@@ -1,0 +1,53 @@
+# Chrome Web Store Listing Copy (Draft)
+
+Use this as starter content when creating the listing.
+
+## Name
+
+OpenCode Browser Automation
+
+## Short description
+
+Automate real Chrome tabs for OpenCode with local native messaging and per-tab session ownership.
+
+## Detailed description
+
+OpenCode Browser Automation connects OpenCode to your real browser tabs so you can automate workflows on sites you authorize.
+
+What it does:
+
+- Open, close, and navigate tabs
+- Click, type, select, query, and scroll on pages
+- Capture snapshots and screenshots
+- Manage downloads and file-input uploads
+- Optional diagnostics for console logs and page errors
+
+Architecture:
+
+- Chrome extension + local native messaging host
+- Local broker enforces per-tab ownership for safer multi-session automation
+
+Important:
+
+- This extension is a companion to OpenCode
+- It requires local setup of the native messaging host
+- It operates on websites only after permissions are granted
+
+## Support URL
+
+https://github.com/different-ai/opencode-browser/issues
+
+## Homepage URL
+
+https://github.com/different-ai/opencode-browser
+
+## Privacy policy URL
+
+Host and link to the published version of `PRIVACY.md`.
+
+## Permission justification (for reviewer notes)
+
+- `scripting` and site access: execute user-requested browser actions on user-authorized websites.
+- `nativeMessaging` (optional): bridge Chrome extension requests to a local companion process.
+- `downloads` (optional): support automation workflows that trigger file downloads.
+- `debugger` (optional): support explicit diagnostics features (console and page errors).

--- a/CHROME_WEB_STORE_REQUEST_TEMPLATE.md
+++ b/CHROME_WEB_STORE_REQUEST_TEMPLATE.md
@@ -1,0 +1,39 @@
+# Request: Publish OpenCode Browser to Chrome Web Store
+
+## Goal
+
+Publish `@different-ai/opencode-browser` extension to Chrome Web Store and pass review.
+
+## Scope
+
+- Publish extension package built from `bun run build:cws`
+- Complete Chrome Web Store listing metadata and data safety disclosures
+- Submit for review and address policy feedback
+
+## Package
+
+- Artifact path: `artifacts/chrome-web-store/opencode-browser-cws-v<version>.zip`
+- Effective store manifest: `artifacts/chrome-web-store/manifest.chrome-web-store.json`
+- Privacy policy source: `PRIVACY.md`
+
+## Acceptance Criteria
+
+- Listing draft is complete with icons, screenshots, description, support URL, and privacy policy URL
+- Data disclosure form is fully completed and aligned with `PRIVACY.md`
+- Submission is sent for review
+- If rejected, reviewer feedback is captured with a concrete remediation checklist
+
+## Known manual blockers
+
+- Chrome Web Store developer account access and payment
+- Identity verification and publisher profile completion
+- Final privacy policy hosted URL
+- Human review turnaround time
+
+## Recommended owner checklist
+
+1. Run `bun run build:cws`
+2. Verify extension loads from `artifacts/chrome-web-store/extension`
+3. Upload zip in Chrome Web Store dashboard
+4. Complete listing and disclosures
+5. Submit and track review status

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,51 @@
+# OpenCode Browser Privacy Policy
+
+Last updated: 2026-02-10
+
+OpenCode Browser is a companion extension for the OpenCode plugin. It automates browser actions based on user requests.
+
+## What data the extension can access
+
+Depending on granted permissions and the sites you allow, the extension can access:
+
+- Website content (DOM text, element attributes, links, forms)
+- User activity related to requested automation steps (clicks, typing, selection)
+- Screenshots and page snapshots requested by the user
+- Download metadata for files initiated by automation
+- Optional diagnostics data (console messages and page errors) when debugger permission is granted
+
+## How data is used
+
+- Data is used only to execute the browser automation commands requested by the user.
+- Data is passed to a local native messaging host (`com.opencode.browser_automation`) and local OpenCode plugin processes.
+- The extension does not include third-party analytics SDKs or ad trackers.
+
+## Data sharing
+
+- The extension itself does not sell personal data.
+- The extension itself does not transfer data to unrelated third parties.
+- If you use OpenCode with remote models or services, data you request OpenCode to process may be sent by OpenCode according to your OpenCode configuration.
+
+## Data retention
+
+- Most data is processed in memory for the active automation session.
+- Console/error buffers are in-memory rolling buffers and are cleared when tabs close, extension restarts, or when explicitly cleared by tool calls.
+- Native host configuration files are stored locally on the machine for installation and runtime setup.
+
+## User controls
+
+- You can remove optional permissions at any time in `chrome://extensions`.
+- You can uninstall the extension and native host at any time.
+- You can disable or remove the OpenCode plugin from your OpenCode configuration.
+
+## Security model
+
+- Native messaging traffic stays on the local machine between Chrome and the local native host.
+- The extension requires explicit permissions and site access.
+
+## Contact
+
+Questions or concerns:
+
+- Project: https://github.com/different-ai/opencode-browser
+- Issues: https://github.com/different-ai/opencode-browser/issues

--- a/README.md
+++ b/README.md
@@ -58,6 +58,25 @@ Your `opencode.json` or `opencode.jsonc` should contain:
 bunx @different-ai/opencode-browser@latest update
 ```
 
+## Chrome Web Store maintainer flow
+
+Build a store-ready extension package:
+
+```bash
+bun run build:cws
+```
+
+Outputs:
+
+- `artifacts/chrome-web-store/opencode-browser-cws-v<version>.zip`
+- `artifacts/chrome-web-store/manifest.chrome-web-store.json`
+
+Submission checklist and guidance:
+
+- `CHROME_WEB_STORE.md`
+- `CHROME_WEB_STORE_REQUEST_TEMPLATE.md`
+- `PRIVACY.md`
+
 ## How it works
 
 ```
@@ -181,3 +200,7 @@ npx @different-ai/opencode-browser uninstall
 ```
 
 Then remove the unpacked extension in `chrome://extensions` and remove the plugin from `opencode.json` or `opencode.jsonc`.
+
+## Privacy
+
+- Privacy policy: `PRIVACY.md`

--- a/build-cws-package.mjs
+++ b/build-cws-package.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+
+import { cp, mkdir, readFile, rm, writeFile } from "fs/promises"
+import { existsSync } from "fs"
+import { dirname, join, resolve } from "path"
+import { fileURLToPath } from "url"
+import { execFileSync } from "child_process"
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+const SOURCE_EXTENSION_DIR = join(__dirname, "extension")
+const OUTPUT_ROOT_DIR = join(__dirname, "artifacts", "chrome-web-store")
+const STAGING_DIR = join(OUTPUT_ROOT_DIR, "extension")
+
+const OPTIONAL_PERMISSIONS = new Set(["nativeMessaging", "downloads", "debugger"])
+
+function sortUnique(values) {
+  return [...new Set(values)].sort()
+}
+
+async function readJson(filePath) {
+  return JSON.parse(await readFile(filePath, "utf8"))
+}
+
+async function writeJson(filePath, data) {
+  await writeFile(filePath, JSON.stringify(data, null, 2) + "\n", "utf8")
+}
+
+function transformManifestForChromeWebStore(manifest) {
+  const next = structuredClone(manifest)
+
+  delete next.key
+
+  const permissions = Array.isArray(next.permissions) ? next.permissions : []
+  const optionalPermissions = new Set(Array.isArray(next.optional_permissions) ? next.optional_permissions : [])
+
+  const requiredPermissions = []
+  for (const permission of permissions) {
+    if (permission === "notifications") continue
+    if (OPTIONAL_PERMISSIONS.has(permission)) {
+      optionalPermissions.add(permission)
+      continue
+    }
+    requiredPermissions.push(permission)
+  }
+
+  next.permissions = sortUnique(requiredPermissions)
+
+  if (optionalPermissions.size) {
+    next.optional_permissions = sortUnique([...optionalPermissions])
+  } else {
+    delete next.optional_permissions
+  }
+
+  const optionalOrigins = new Set(Array.isArray(next.optional_host_permissions) ? next.optional_host_permissions : [])
+  const hostPermissions = Array.isArray(next.host_permissions) ? next.host_permissions : []
+  for (const origin of hostPermissions) {
+    optionalOrigins.add(origin)
+  }
+
+  delete next.host_permissions
+
+  if (optionalOrigins.size) {
+    next.optional_host_permissions = sortUnique([...optionalOrigins])
+  } else {
+    delete next.optional_host_permissions
+  }
+
+  return next
+}
+
+function buildZip(stagingDir, outputZipPath) {
+  const zipBinary = "zip"
+  execFileSync(zipBinary, ["-qr", outputZipPath, "."], { cwd: stagingDir, stdio: "inherit" })
+}
+
+async function main() {
+  if (!existsSync(SOURCE_EXTENSION_DIR)) {
+    throw new Error(`Missing extension directory: ${SOURCE_EXTENSION_DIR}`)
+  }
+
+  await mkdir(OUTPUT_ROOT_DIR, { recursive: true })
+  await rm(STAGING_DIR, { recursive: true, force: true })
+  await cp(SOURCE_EXTENSION_DIR, STAGING_DIR, { recursive: true })
+
+  const manifestPath = join(STAGING_DIR, "manifest.json")
+  const manifest = await readJson(manifestPath)
+  const transformedManifest = transformManifestForChromeWebStore(manifest)
+  await writeJson(manifestPath, transformedManifest)
+
+  const version = transformedManifest.version || "0.0.0"
+  const zipPath = resolve(join(OUTPUT_ROOT_DIR, `opencode-browser-cws-v${version}.zip`))
+  await rm(zipPath, { force: true })
+  buildZip(STAGING_DIR, zipPath)
+
+  const metadataPath = join(OUTPUT_ROOT_DIR, "manifest.chrome-web-store.json")
+  await writeJson(metadataPath, transformedManifest)
+
+  console.log("\nChrome Web Store package ready:")
+  console.log(`- Zip: ${zipPath}`)
+  console.log(`- Staging: ${STAGING_DIR}`)
+  console.log(`- Store manifest: ${metadataPath}`)
+}
+
+main().catch((error) => {
+  console.error(`Failed to build Chrome Web Store package: ${error?.message || String(error)}`)
+  process.exit(1)
+})

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
   ],
   "scripts": {
     "build": "bun build src/plugin.ts --target=node --outfile=dist/plugin.js",
+    "build:cws": "node build-cws-package.mjs",
+    "check:extension": "node --check extension/background.js",
     "prepublishOnly": "bun run build",
     "publish": "node -e \"if (process.env.npm_command === 'publish') process.exit(0); require('child_process').execSync('npm publish --access public', { stdio: 'inherit' });\"",
     "install": "node bin/cli.js install",


### PR DESCRIPTION
## Summary
- add a Chrome Web Store packaging pipeline that builds a store-safe manifest and zip artifact (`bun run build:cws`)
- update the extension runtime to request optional permissions on click and gracefully degrade when native messaging/site access/debugger/download permissions are not granted
- add maintainer docs and templates for submission, privacy disclosures, and listing copy

## Testing
- node --check extension/background.js
- node --check bin/broker.cjs && node --check bin/native-host.cjs
- bun run build
- bun run build:cws
- Chrome pack validation on generated store staging extension
- Chrome MCP navigation checks and screenshots for extensions page + CWS pages