### PR TITLE
feat: add CLI tool runner and harden list UI interactions

### DIFF
--- a/.opencode/skill/browser-automation/SKILL.md
+++ b/.opencode/skill/browser-automation/SKILL.md
@@ -13,6 +13,7 @@ metadata:
 - Provide a safe, composable workflow for browsing tasks
 - Use `browser_query` list and index selection to click reliably
 - Confirm state changes after each action
+- Support CLI-first debugging with `opencode-browser tool` commands
 
 ## Best-practice workflow
 
@@ -23,6 +24,16 @@ metadata:
 5. Discover candidates using `browser_query` with `mode=list`
 6. Click, type, or select using `index`
 7. Confirm using `browser_query` or `browser_snapshot`
+
+## CLI-first debugging
+
+- List all available tools: `npx @different-ai/opencode-browser tools`
+- Run one tool directly: `npx @different-ai/opencode-browser tool browser_status`
+- Pass JSON args: `npx @different-ai/opencode-browser tool browser_query --args '{"mode":"page_text"}'`
+- Run smoke test: `npx @different-ai/opencode-browser self-test`
+- After `update`, reload the unpacked extension in `chrome://extensions`
+
+This path is useful for reproducing selector/scroll issues quickly before running a full OpenCode session.
 
 ## Selecting options
 
@@ -46,5 +57,7 @@ metadata:
 ## Troubleshooting
 
 - If a selector fails, run `browser_query` with `mode=page_text` to confirm the content exists
-- Use `mode=list` on broad selectors (`button`, `a`, `*[role="button"]`) and choose by index
+- Use `mode=list` on broad selectors (`button`, `a`, `*[role="button"]`, `*[role="listitem"]`) and choose by index
+- For inbox/chat panes, try text selectors first (`text:Subject line`) then verify selection with `browser_query`
+- For scrollable containers, pass both `selector` and `x`/`y` to `browser_scroll` and then verify `scrollTop`
 - Confirm results after each action

--- a/README.md
+++ b/README.md
@@ -58,6 +58,25 @@ Your `opencode.json` or `opencode.jsonc` should contain:
 bunx @different-ai/opencode-browser@latest update
 ```
 
+## CLI tool runner (for local debugging)
+
+Run plugin tools directly from the package CLI (without starting an OpenCode session):
+
+```bash
+# list available browser_* tools
+npx @different-ai/opencode-browser tools
+
+# run a single tool
+npx @different-ai/opencode-browser tool browser_status
+npx @different-ai/opencode-browser tool browser_query --args '{"mode":"page_text"}'
+
+# run built-in end-to-end smoke test (click + text selector + container scroll)
+npx @different-ai/opencode-browser self-test
+```
+
+This is useful for debugging issue reports (for example inbox/chat UIs) before involving a full OpenCode workflow.
+After `update`, reload the unpacked extension in `chrome://extensions` before running `self-test`.
+
 ## Chrome Web Store maintainer flow
 
 Build a store-ready extension package:

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "install": "node bin/cli.js install",
     "uninstall": "node bin/cli.js uninstall",
     "status": "node bin/cli.js status",
+    "tools": "node bin/cli.js tools",
+    "self-test": "node bin/cli.js self-test",
     "tool-test": "bun bin/tool-test.ts"
   },
   "keywords": [


### PR DESCRIPTION
## Summary
- add package CLI commands to list and execute any browser tool directly (`tools`, `tool`, `self-test`) for faster issue reproduction without a full OpenCode session
- improve `text:` targeting for inbox/chat style UIs by including additional interactive list roles and likely-clickable nodes
- make selector-based scrolling apply `x/y` to the matched container element and document the new debugging flow in README and browser automation skill

## Why
Issue #8 reports that chat/mail UIs are visible but actions fail when opening conversations or scrolling. This change makes those flows easier to debug from CLI and strengthens the extension behavior for list-style interfaces.

Closes #8