### PR TITLE
Prefer which node over process.execPath to find out node path

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -232,14 +232,19 @@ function ensureDir(p) {
 
 function resolveNodePath() {
   if (process.env.OPENCODE_BROWSER_NODE) return process.env.OPENCODE_BROWSER_NODE;
-  if (process.execPath && /node(\.exe)?$/.test(process.execPath)) return process.execPath;
+  // Prefer `which node` / `where node` — returns stable symlink paths (e.g.
+  // /opt/homebrew/bin/node) rather than versioned paths (e.g.
+  // /opt/homebrew/Cellar/node/25.8.1/bin/node) that break on package manager
+  // upgrades (Homebrew, nvm, fnm, volta, etc.).
   try {
     const command = isWindows() ? "where node" : "which node";
     const output = execSync(command, { stdio: ["ignore", "pipe", "ignore"] })
       .toString("utf8")
       .trim();
     if (output) return output;
-  } catch {}
+  } catch {
+      if (process.execPath && /node(\.exe)?$/.test(process.execPath)) return process.execPath;
+  }
   return process.execPath;
 }
 


### PR DESCRIPTION
resolveNodePath() previously prioritised process.execPath, which on Homebrew resolves to a versioned Cellar path (e.g. /opt/homebrew/Cellar/node/25.8.1/bin/node). This path breaks silently after a brew upgrade node, causing the native messaging host to fail to launch and the Chrome extension to lose its connection.

This fix swaps the resolution order so which node (or where node on Windows) is tried first. Package managers like Homebrew, nvm, fnm, and volta all expose a stable symlink (e.g. /opt/homebrew/bin/node) via PATH, which survives upgrades. process.execPath is kept as a fallback for environments where which may not be available.