### PR TITLE
Fix walkAXTree ignoring children of ignored nodes

### DIFF
--- a/dist/plugin.js
+++ b/dist/plugin.js
@@ -4,25 +4,43 @@ var __getProtoOf = Object.getPrototypeOf;
 var __defProp = Object.defineProperty;
 var __getOwnPropNames = Object.getOwnPropertyNames;
 var __hasOwnProp = Object.prototype.hasOwnProperty;
+function __accessProp(key) {
+  return this[key];
+}
+var __toESMCache_node;
+var __toESMCache_esm;
 var __toESM = (mod, isNodeMode, target) => {
+  var canCache = mod != null && typeof mod === "object";
+  if (canCache) {
+    var cache = isNodeMode ? __toESMCache_node ??= new WeakMap : __toESMCache_esm ??= new WeakMap;
+    var cached = cache.get(mod);
+    if (cached)
+      return cached;
+  }
   target = mod != null ? __create(__getProtoOf(mod)) : {};
   const to = isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target;
   for (let key of __getOwnPropNames(mod))
     if (!__hasOwnProp.call(to, key))
       __defProp(to, key, {
-        get: () => mod[key],
+        get: __accessProp.bind(mod, key),
         enumerable: true
       });
+  if (canCache)
+    cache.set(mod, to);
   return to;
 };
 var __commonJS = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports);
+var __returnValue = (v) => v;
+function __exportSetter(name, newValue) {
+  this[name] = __returnValue.bind(null, newValue);
+}
 var __export = (target, all) => {
   for (var name in all)
     __defProp(target, name, {
       get: all[name],
       enumerable: true,
       configurable: true,
-      set: (newValue) => all[name] = () => newValue
+      set: __exportSetter.bind(all, name)
     });
 };
 var __require = /* @__PURE__ */ createRequire(import.meta.url);
@@ -13615,7 +13633,7 @@ class JSONSchemaGenerator {
               if (val === undefined) {
                 if (this.unrepresentable === "throw") {
                   throw new Error("Literal `undefined` cannot be represented in JSON Schema");
-                } else {}
+                }
               } else if (typeof val === "bigint") {
                 if (this.unrepresentable === "throw") {
                   throw new Error("BigInt literals cannot be represented in JSON Schema");
@@ -15332,8 +15350,26 @@ function walkAXTree(axNode, allNodes, byUid) {
   const value = axNode.value?.value;
   const backendNodeId = axNode.backendDOMNodeId ?? 0;
   const ignored = axNode.ignored;
-  if (ignored && !name)
-    return null;
+  if (ignored && !name) {
+    const childIds2 = axNode.childIds ?? [];
+    const children2 = [];
+    for (const childId of childIds2) {
+      const childAx = allNodes[childId];
+      if (!childAx)
+        continue;
+      const childNode = walkAXTree(childAx, allNodes, byUid);
+      if (childNode)
+        children2.push(childNode);
+    }
+    if (children2.length === 0)
+      return null;
+    if (children2.length === 1)
+      return children2[0];
+    const uid2 = nextUid++;
+    const node2 = { uid: uid2, role: "generic", children: children2 };
+    byUid.set(uid2, node2);
+    return node2;
+  }
   const uid = nextUid++;
   const children = [];
   const childIds = axNode.childIds ?? [];

--- a/src/lib/snapshot.ts
+++ b/src/lib/snapshot.ts
@@ -32,7 +32,22 @@ function walkAXTree(
   const backendNodeId = (axNode.backendDOMNodeId as number | undefined) ?? 0;
   const ignored = axNode.ignored as boolean;
 
-  if (ignored && !name) return null;
+  if (ignored && !name) {
+    const childIds = (axNode.childIds as string[] | undefined) ?? [];
+    const children: SnapshotNode[] = [];
+    for (const childId of childIds) {
+      const childAx = allNodes[childId];
+      if (!childAx) continue;
+      const childNode = walkAXTree(childAx, allNodes, byUid);
+      if (childNode) children.push(childNode);
+    }
+    if (children.length === 0) return null;
+    if (children.length === 1) return children[0];
+    const uid = nextUid++;
+    const node: SnapshotNode = { uid, role: "generic", children };
+    byUid.set(uid, node);
+    return node;
+  }
 
   const uid = nextUid++;
   const children: SnapshotNode[] = [];


### PR DESCRIPTION
## Problem

`browser_snapshot` only returned the root element on real websites (e.g. Google, Example Domain). The accessibility tree was being truncated because `walkAXTree` returned `null` immediately for any `ignored` node without a name, cutting off its entire subtree.

## Root Cause

Chrome's accessibility tree wraps content in `<div>` containers with role `none` and `ignored=true`. When `walkAXTree` encountered these nodes, the early `return null` at line 35 prevented traversal into their children, which contained the actual page content.

## Fix

Instead of returning `null`, the function now:
- Recursively processes children of ignored+noname nodes
- Returns `null` if no children remain (0 children)
- Promotes the child up (1 child)
- Wraps multiple children in a transparent `generic` container

## Testing

Verified with a standalone CDP script and in OpenCode against:
- `example.com` — heading, paragraph, link all appear
- `google.com` — full page tree with search box, buttons, results
- `browser_fill` and `browser_click` now work with the returned UIDs